### PR TITLE
Updated Android SDK link

### DIFF
--- a/_documentation/03-setting-up-an-android-hive.md
+++ b/_documentation/03-setting-up-an-android-hive.md
@@ -23,7 +23,7 @@ unsuitable for our CI needs.
 
 ## Pre-requisites
 
-Install the [Android SDK](#). You should ensure that the follwoing commands are
+Install the <a href="https://developer.android.com/studio/index.html#downloads" target="_blank">Android SDK</a>. You should ensure that the follwoing commands are
 available on the command line:
 
 * `adb`

--- a/_documentation/03-setting-up-an-android-hive.md
+++ b/_documentation/03-setting-up-an-android-hive.md
@@ -23,8 +23,7 @@ unsuitable for our CI needs.
 
 ## Pre-requisites
 
-Install the <a href="https://developer.android.com/studio/index.html#downloads" target="_blank">Android SDK</a>. You should ensure that the follwoing commands are
-available on the command line:
+Install the [Android SDK](https://developer.android.com/studio/index.html#downloads). You should ensure that the following commands are available on the command line:
 
 * `adb`
 * `aapt`


### PR DESCRIPTION
Android SDK should now point to https://developer.android.com/studio/index.html#downloads and opens in new tab
